### PR TITLE
Update to use modern Rust dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "rust-users"
 version = "0.1.0"
+authors = [ "Ryan Chenkie <ryanchenkie@gmail.com>" ]
 edition = "2021"
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,5 +10,5 @@ env_logger = "0.10"
 mongodb = "2.3"
 serde = { version = "1.0", features = ["derive"] }
 jsonwebtoken = "8.1"
-futures = "0.3"
-sha2 = "0.10"
+futures-util = "0.3"
+futures = "0.3.30"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
-
 name = "rust-users"
-version = "0.0.1"
-authors = [ "Ryan Chenkie <ryanchenkie@gmail.com>" ]
+version = "0.1.0"
+edition = "2021"
 
 [dependencies]
-nickel = "*"
-mongodb = "*"
-bson = "*"
-rustc-serialize = "*"
-hyper = "*"
-jwt = "*"
-rust-crypto = "*"
+actix-web = "4.0"
+actix-service = "2.0"
+env_logger = "0.10"
+mongodb = "2.3"
+serde = { version = "1.0", features = ["derive"] }
+jsonwebtoken = "8.1"
+futures = "0.3"
+sha2 = "0.10"

--- a/readme.md
+++ b/readme.md
@@ -2,6 +2,76 @@
 
 This repo shows how to implement a RESTful API in Rust with **[Actix Web](https://actix.rs/)** and the **[MongoDB Rust Driver](https://www.mongodb.com/docs/drivers/rust/current/)**.
 
+This REST API uses simple JWT authentication. Note that it does not actually integrate with Auth0!
+
+## Prerequisites
+
+You will need to have MongoDB installed and running on `localhost:27017`. If on macOS, for instance, follow MongoDB's [installation instructions](https://www.mongodb.com/docs/manual/tutorial/install-mongodb-on-os-x/).
+
+## Usage
+
+Issue a POST to the `/login` route to obtain a JWT bearer token.
+
+```
+% curl -v http://127.0.0.1:9000/login -X POST -d '{"email": "Joe User", "password": "secret"}' -H "Content-Type: application/json"
+Note: Unnecessary use of -X or --request, POST is already inferred.
+*   Trying 127.0.0.1:9000...
+* Connected to 127.0.0.1 (127.0.0.1) port 9000
+> POST /login HTTP/1.1
+> Host: 127.0.0.1:9000
+> User-Agent: curl/8.4.0
+> Accept: */*
+> Content-Type: application/json
+> Content-Length: 43
+>
+< HTTP/1.1 200 OK
+< content-length: 180
+< date: Wed, 10 Jul 2024 14:20:55 GMT
+<
+* Connection #0 to host 127.0.0.1 left intact
+eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpYXQiOjE3MjA2MjEyNTYsImV4cCI6MTcyMDYyNDg1NiwiZW1haWwiOiJKb2UgVXNlciIsInBhc3N3b3JkIjoic2VjcmV0In0.CLi9Jc34GUOMuHuK7KDN2BUI2-vX6KI4yfnIN6ngm0E
+```
+
+The JWT bearer token can now be specified to the protected routes such as `/users` and `/users/new`.
+
+```
+% curl -v -H "Authorization: Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpYXQiOjE3MjA2MjEyNTYsImV4cCI6MTcyMDYyNDg1NiwiZW1haWwiOiJKb2UgVXNlciIsInBhc3N3b3JkIjoic2VjcmV0In0.CLi9Jc34GUOMuHuK7KDN2BUI2-vX6KI4yfnIN6ngm0E" http://127.0.0.1:9000/users -X POST -d '{"firstname": "Joe", "lastname": "User", "email": "joe@example.org"}' -H "Content-Type: application/json" 
+Note: Unnecessary use of -X or --request, POST is already inferred.
+*   Trying 127.0.0.1:9000...
+* Connected to 127.0.0.1 (127.0.0.1) port 9000
+> POST /users HTTP/1.1
+> Host: 127.0.0.1:9000
+> User-Agent: curl/8.4.0
+> Accept: */*
+> Authorization: Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpYXQiOjE3MjA2MjEyNTYsImV4cCI6MTcyMDYyNDg1NiwiZW1haWwiOiJKb2UgVXNlciIsInBhc3N3b3JkIjoic2VjcmV0In0.CLi9Jc34GUOMuHuK7KDN2BUI2-vX6KI4yfnIN6ngm0E
+> Content-Type: application/json
+> Content-Length: 68
+>
+< HTTP/1.1 200 OK
+< content-length: 11
+< date: Wed, 10 Jul 2024 14:23:07 GMT
+<
+* Connection #0 to host 127.0.0.1 left intact
+Item saved!
+
+% curl -v -H "Authorization: Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpYXQiOjE3MjA2MjEyNTYsImV4cCI6MTcyMDYyNDg1NiwiZW1haWwiOiJKb2UgVXNlciIsInBhc3N3b3JkIjoic2VjcmV0In0.CLi9Jc34GUOMuHuK7KDN2BUI2-vX6KI4yfnIN6ngm0E" http://127.0.0.1:9000/users
+*   Trying 127.0.0.1:9000...
+* Connected to 127.0.0.1 (127.0.0.1) port 9000
+> GET /users HTTP/1.1
+> Host: 127.0.0.1:9000
+> User-Agent: curl/8.4.0
+> Accept: */*
+> Authorization: Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpYXQiOjE3MjA2MjEyNTYsImV4cCI6MTcyMDYyNDg1NiwiZW1haWwiOiJKb2UgVXNlciIsInBhc3N3b3JkIjoic2VjcmV0In0.CLi9Jc34GUOMuHuK7KDN2BUI2-vX6KI4yfnIN6ngm0E
+>
+< HTTP/1.1 200 OK
+< content-length: 127
+< content-type: application/json
+< date: Wed, 10 Jul 2024 14:23:51 GMT
+<
+* Connection #0 to host 127.0.0.1 left intact
+{"data":[{ "_id": ObjectId("668e994c7eba267f28496f8a"), "firstname": "Joe", "lastname": "User", "email": "joe@example.org" },]}
+```
+
 ## Important Snippets
 
 The simple example has `GET`, `POST`, and `DELETE` routes in the `main` function.
@@ -48,7 +118,7 @@ async fn get_users() -> impl Responder {
 ...
 ```
 
-The **POST** `/users/new` route takes JSON data and saves in the database. The data conforms to the `User` struct.
+The **POST** `/users` route takes JSON data and saves in the database. The data conforms to the `User` struct.
 
 ```rust
 // src/main.rs

--- a/readme.md
+++ b/readme.md
@@ -32,7 +32,7 @@ Note: Unnecessary use of -X or --request, POST is already inferred.
 eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpYXQiOjE3MjA2MjEyNTYsImV4cCI6MTcyMDYyNDg1NiwiZW1haWwiOiJKb2UgVXNlciIsInBhc3N3b3JkIjoic2VjcmV0In0.CLi9Jc34GUOMuHuK7KDN2BUI2-vX6KI4yfnIN6ngm0E
 ```
 
-The JWT bearer token can now be specified to the protected routes such as `/users` and `/users/new`.
+The JWT bearer token can now be specified to the protected routes such as `/users`.
 
 ```
 % curl -v -H "Authorization: Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpYXQiOjE3MjA2MjEyNTYsImV4cCI6MTcyMDYyNDg1NiwiZW1haWwiOiJKb2UgVXNlciIsInBhc3N3b3JkIjoic2VjcmV0In0.CLi9Jc34GUOMuHuK7KDN2BUI2-vX6KI4yfnIN6ngm0E" http://127.0.0.1:9000/users -X POST -d '{"firstname": "Joe", "lastname": "User", "email": "joe@example.org"}' -H "Content-Type: application/json" 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,256 +1,160 @@
-#[macro_use] 
-extern crate nickel;
-extern crate rustc_serialize;
+use actix_web::{web, App, HttpServer, HttpRequest, HttpResponse, Responder, middleware::Logger};
+use mongodb::{Client, options::ClientOptions, bson::{doc, oid::ObjectId, Document}};
+use serde::{Deserialize, Serialize};
+use jsonwebtoken::{encode, decode, Header, Validation, EncodingKey, DecodingKey};
+use futures::StreamExt;
 
-#[macro_use(bson, doc)]
-extern crate bson;
-extern crate mongodb;
-extern crate hyper;
-extern crate crypto;
-extern crate jwt;
-
-// Nickel
-use nickel::{Nickel, JsonBody, HttpRouter, Request, Response, MiddlewareResult, MediaType};
-use nickel::status::StatusCode::{self, Forbidden};
-
-// MongoDB
-use mongodb::{Client, ThreadedClient};
-use mongodb::db::ThreadedDatabase;
-use mongodb::error::Result as MongoResult;
-
-// bson
-use bson::{Bson, Document};
-use bson::oid::ObjectId;
-
-// rustc_serialize
-use rustc_serialize::json::{Json, ToJson};
-use rustc_serialize::base64;
-use rustc_serialize::base64::{FromBase64};
-
-// hyper
-use hyper::header;
-use hyper::header::{Authorization, Bearer};
-use hyper::method::Method;
-
-// jwt
-use std::default::Default;
-use crypto::sha2::Sha256;
-use jwt::{
-    Header,
-    Registered,
-    Token,
-};
-
-#[derive(RustcDecodable, RustcEncodable)]
+#[derive(Serialize, Deserialize)]
 struct User {
     firstname: String,
     lastname: String,
-    email: String
+    email: String,
 }
 
-static AUTH_SECRET: &'static str = "your_secret_key";
-
-#[derive(RustcDecodable, RustcEncodable)]
+#[derive(Serialize, Deserialize)]
 struct UserLogin {
     email: String,
-    password: String
+    password: String,
 }
 
-fn get_data_string(result: MongoResult<Document>) -> Result<Json, String> {
+static AUTH_SECRET: &str = "your_secret_key";
+
+async fn get_data_string(result: mongodb::error::Result<Document>) -> Result<web::Json<Document>, String> {
     match result {
-        Ok(doc) => Ok(Bson::Document(doc).to_json()),
-        Err(e) => Err(format!("{}", e))
+        Ok(doc) => Ok(web::Json(doc)),
+        Err(e) => Err(format!("{}", e)),
     }
 }
 
-fn authenticator<'mw>(request: &mut Request, response: Response<'mw>, ) -> MiddlewareResult<'mw> {
+async fn authenticator(
+    req: HttpRequest,
+    srv: &dyn actix_service::Service<
+        HttpRequest,
+        Response = HttpResponse,
+        Error = actix_web::Error,
+        Future = impl std::future::Future<Output = Result<HttpResponse, actix_web::Error>>,
+    >,
+) -> impl Responder {
+    if req.method() == "OPTIONS" {
+        return srv.call(req).await;
+    }
 
-  // Check if we are getting an OPTIONS request
-  if request.origin.method.to_string() == "OPTIONS".to_string() {
+    if req.path() == "/login" {
+        return srv.call(req).await;
+    }
 
-      // The middleware shouldn't be used for OPTIONS, so continue
-      response.next_middleware()
+    let auth_header = match req.headers().get("Authorization") {
+        Some(header) => header.to_str().unwrap_or(""),
+        None => "",
+    };
 
-  } else {
-
-    // We don't want to apply the middleware to the login route
-    if request.origin.uri.to_string() == "/login".to_string() {
-
-        response.next_middleware()
-
+    let jwt = if auth_header.starts_with("Bearer ") {
+        &auth_header[7..]
     } else {
+        ""
+    };
 
-        // Get the full Authorization header from the incoming request headers
-        let auth_header = match request.origin.headers.get::<Authorization<Bearer>>() {
-            Some(header) => header,
-            None => panic!("No authorization header found")
-        };
+    let token_data = decode::<UserLogin>(&jwt, &DecodingKey::from_secret(AUTH_SECRET.as_ref()), &Validation::default());
 
-        // Format the header to only take the value
-        let jwt = header::HeaderFormatter(auth_header).to_string();
-
-        // We don't need the Bearer part, 
-        // so get whatever is after an index of 7
-        let jwt_slice = &jwt[7..];
-
-        // Parse the token
-        let token = Token::<Header, Registered>::parse(jwt_slice).unwrap();
-
-        // Get the secret key as bytes
-        let secret = AUTH_SECRET.as_bytes();
-
-        // Generic example
-        // Verify the token
-        if token.verify(&secret, Sha256::new()) {
-          
-            response.next_middleware()         
-          
-        } else {
-
-            response.error(Forbidden, "Access denied")
-
-        }
-
+    match token_data {
+        Ok(_) => srv.call(req).await,
+        Err(_) => Ok(HttpResponse::Forbidden().finish()),
     }
-  }
 }
 
-fn main() {
+#[actix_web::main]
+async fn main() -> std::io::Result<()> {
+    env_logger::init();
 
-    let mut server = Nickel::new();
-    let mut router = Nickel::router();
+    HttpServer::new(|| {
+        App::new()
+            .wrap(Logger::default())
+            .service(
+                web::resource("/login")
+                    .route(web::post().to(login))
+            )
+            .service(
+                web::resource("/users")
+                    .route(web::get().to(get_users))
+                    .route(web::post().to(new_user))
+            )
+            .service(
+                web::resource("/users/{id}")
+                    .route(web::delete().to(delete_user))
+            )
+    })
+    .bind("127.0.0.1:9000")?
+    .run()
+    .await
+}
 
-    server.utilize(authenticator);
+async fn login(info: web::Json<UserLogin>) -> impl Responder {
+    let email = info.email.clone();
+    let password = info.password.clone();
 
-    router.post("/login", middleware! { |request|
+    if password == "secret" {
+        let claims = UserLogin { email, password };
+        let token = encode(&Header::default(), &claims, &EncodingKey::from_secret(AUTH_SECRET.as_ref())).unwrap();
 
-        // Accept a JSON string that corresponds to the User struct
-        let user = request.json_as::<UserLogin>().unwrap();
+        HttpResponse::Ok().body(token)
+    } else {
+        HttpResponse::BadRequest().body("Incorrect username or password")
+    }
+}
 
-        // Get the email and password
-        let email = user.email.to_string();
-        let password = user.password.to_string();
+async fn get_users() -> impl Responder {
+    let client_options = ClientOptions::parse("mongodb://localhost:27017").await.unwrap();
+    let client = Client::with_options(client_options).unwrap();
 
-        // Simple password checker
-        if password == "secret".to_string() {
+    let collection = client.database("rust-users").collection::<Document>("users");
+    let mut cursor = collection.find(None, None).await.unwrap();
 
-            let header: Header = Default::default();
+    let mut data_result = "{\"data\":[".to_owned();
 
-            // For the example, we just have one claim
-            // You would also want iss, exp, iat etc
-            let claims = Registered {
-                sub: Some(email.into()),
-                ..Default::default()
-            };
-
-            let token = Token::new(header, claims);
-
-            // Sign the token
-            let jwt = token.signed(AUTH_SECRET.as_bytes(), Sha256::new()).unwrap();
-
-            format!("{}", jwt)
-
-        } else {
-            format!("Incorrect username or password")
-        }
-
-    });
-
-    router.get("/users", middleware! { |request, mut response|
-
-        // Connect to the database
-        let client = Client::connect("localhost", 27017)
-          .ok().expect("Error establishing connection.");
-
-        // The users collection
-        let coll = client.db("rust-users").collection("users");
-
-        // Create cursor that finds all documents
-        let cursor = coll.find(None, None).unwrap();
-
-        // Opening for the JSON string to be returned
-        let mut data_result = "{\"data\":[".to_owned();
-
-        for (i, result) in cursor.enumerate() {
-            match get_data_string(result) {
-                Ok(data) => {
-                    let string_data = if i == 0 { 
-                        format!("{}", data)
-                    } else {
-                        format!("{},", data)
-                    };
-
-                    data_result.push_str(&string_data);
-                },
-
-                Err(e) => return response.send(format!("{}", e))
+    while let Some(result) = cursor.next().await {
+        match get_data_string(result).await {
+            Ok(data) => {
+                let string_data = format!("{},", data.into_inner());
+                data_result.push_str(&string_data);
             }
+            Err(e) => return HttpResponse::InternalServerError().body(e),
         }
+    }
 
-        // Close the JSON string
-        data_result.push_str("]}");
+    data_result.push_str("]}");
+    HttpResponse::Ok()
+        .content_type("application/json")
+        .body(data_result)
+}
 
-        // Set the returned type as JSON
-        response.set(MediaType::Json);
+async fn new_user(info: web::Json<User>) -> impl Responder {
+    let client_options = ClientOptions::parse("mongodb://localhost:27017").await.unwrap();
+    let client = Client::with_options(client_options).unwrap();
 
-        // Send back the result
-        format!("{}", data_result)
+    let collection = client.database("rust-users").collection::<Document>("users");
+    let user = doc! {
+        "firstname": &info.firstname,
+        "lastname": &info.lastname,
+        "email": &info.email,
+    };
 
-    });
+    match collection.insert_one(user, None).await {
+        Ok(_) => HttpResponse::Ok().body("Item saved!"),
+        Err(e) => HttpResponse::InternalServerError().body(format!("{}", e)),
+    }
+}
 
-    router.post("/users/new", middleware! { |request, response|
+async fn delete_user(req: HttpRequest) -> impl Responder {
+    let client_options = ClientOptions::parse("mongodb://localhost:27017").await.unwrap();
+    let client = Client::with_options(client_options).unwrap();
 
-        // Accept a JSON string that corresponds to the User struct
-        let user = request.json_as::<User>().unwrap();
+    let collection = client.database("rust-users").collection::<Document>("users");
+    let object_id = req.match_info().get("id").unwrap();
 
-        let firstname = user.firstname.to_string();
-        let lastname = user.lastname.to_string();
-        let email = user.email.to_string();
+    let id = ObjectId::parse_str(object_id).unwrap();
 
-        // Connect to the database
-        let client = Client::connect("localhost", 27017)
-            .ok().expect("Error establishing connection.");
-
-        // The users collection
-        let coll = client.db("rust-users").collection("users");
-
-        // Insert one user
-        match coll.insert_one(doc! { 
-            "firstname" => firstname,
-            "lastname" => lastname,
-            "email" => email 
-        }, None) {
-            Ok(_) => (StatusCode::Ok, "Item saved!"),
-            Err(e) => return response.send(format!("{}", e))
-        }
-
-    });
-
-    router.delete("/users/:id", middleware! { |request, response|
-
-        let client = Client::connect("localhost", 27017)
-            .ok().expect("Failed to initialize standalone client.");
-
-        // The users collection
-        let coll = client.db("rust-users").collection("users");
-
-        // Get the user_id from the request params
-        let object_id = request.param("id").unwrap();
-
-        // Match the user id to an bson ObjectId
-        let id = match ObjectId::with_string(object_id) {
-            Ok(oid) => oid,
-            Err(e) => return response.send(format!("{}", e))
-        };
-
-        match coll.delete_one(doc! {"_id" => id}, None) {
-            Ok(_) => (StatusCode::Ok, "Item deleted!"),
-            Err(e) => return response.send(format!("{}", e))
-        }
-
-    });
-
-    server.utilize(router);
-
-    server.listen("127.0.0.1:9000");
+    match collection.delete_one(doc! {"_id": id}, None).await {
+        Ok(_) => HttpResponse::Ok().body("Item deleted!"),
+        Err(e) => HttpResponse::InternalServerError().body(format!("{}", e)),
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,7 +32,8 @@ struct SessionJWT {
     password: String,
 }
 
-static AUTH_SECRET: &str = "ef3b28c9951edd3151d9abb14e8e2909b5fc535c986e7cb588b32b0d2082a9b9";
+static AUTH_SECRET: &str = "your_secret_key";
+static JWT_EXPIRATION_SECS: u64 = 3600;
 
 async fn get_data_string(result: mongodb::error::Result<Document>) -> Result<web::Json<Document>, String> {
     match result {
@@ -138,9 +139,8 @@ async fn login(info: web::Json<UserLogin>) -> impl Responder {
             .duration_since(UNIX_EPOCH)
             .expect("Time went backwards")
             .as_secs();
-        println!("{:?}", since_the_epoch);
 
-        let claims = SessionJWT { iat: since_the_epoch, exp: since_the_epoch+3600, email, password };
+        let claims = SessionJWT { iat: since_the_epoch, exp: since_the_epoch+JWT_EXPIRATION_SECS, email, password };
         let token = encode(&Header::default(), &claims, &EncodingKey::from_secret(AUTH_SECRET.as_ref())).unwrap();
 
         HttpResponse::Ok().body(token)


### PR DESCRIPTION
This sample is 9 years old, and because it doesn't pin versions in `Cargo.toml`, it no longer compiles out of the box. It also depends on unsupported and deprecated lIbraries such as `rustc-serialize`.

- `nickel` web framework replaced with `actix-web`, which is a modern and actively maintained Rust web framework.
- `rustc_serialize` crate replaced with `serde` for serialization and deserialization.
- `mongodb` crate syntax updated to the latest version, with `async/await` support.
- `jwt` crate is replaced with `jsonwebtoken`, which is a commonly used JWT library in Rust.
- `hyper` crate and related HTTP utilities are replaced by actix-web features.
- The updated code uses `env_logger` for logging, `actix_web::middleware::Logger` for request logging, and `futures::StreamExt` for MongoDB cursor handling.